### PR TITLE
Scoping fix

### DIFF
--- a/generate-ebooks.py
+++ b/generate-ebooks.py
@@ -229,15 +229,15 @@ def rewriteImageLinks(posts):
 
                     # Resize images to a max width of 800px to save space
                     try:
-                        image = Image.open(cachedImagePath)
-                        image.LOAD_TRUNCATED_IMAGES = True
-                        if not image.width <= 600:
-                            aspectRatioChange = IMG_MAX_WIDTH_PX / image.width
-                            height = int(image.height * aspectRatioChange)
+                        image2 = Image.open(cachedImagePath)
+                        image2.LOAD_TRUNCATED_IMAGES = True
+                        if not image2.width <= 600:
+                            aspectRatioChange = IMG_MAX_WIDTH_PX / image2.width
+                            height = int(image2.height * aspectRatioChange)
                             newSize = (IMG_MAX_WIDTH_PX, height)
-                            image = image.resize(newSize)
+                            image2 = image2.resize(newSize)
 
-                        image.save(cachedImagePath, optimize=True, quality=85)
+                        image2.save(cachedImagePath, optimize=True, quality=85)
                     except IOError as e:
                         print(f'Failed to open image at path {cachedImagePath} for resize, caching at original resolution, error: {e}')
                 except Exception as e:

--- a/generate-ebooks.py
+++ b/generate-ebooks.py
@@ -229,15 +229,15 @@ def rewriteImageLinks(posts):
 
                     # Resize images to a max width of 800px to save space
                     try:
-                        image2 = Image.open(cachedImagePath)
-                        image2.LOAD_TRUNCATED_IMAGES = True
-                        if not image2.width <= 600:
-                            aspectRatioChange = IMG_MAX_WIDTH_PX / image2.width
-                            height = int(image2.height * aspectRatioChange)
+                        imageFile = Image.open(cachedImagePath)
+                        imageFile.LOAD_TRUNCATED_IMAGES = True
+                        if not imageFile.width <= 600:
+                            aspectRatioChange = IMG_MAX_WIDTH_PX / imageFile.width
+                            height = int(imageFile.height * aspectRatioChange)
                             newSize = (IMG_MAX_WIDTH_PX, height)
-                            image2 = image2.resize(newSize)
+                            imageFile = imageFile.resize(newSize)
 
-                        image2.save(cachedImagePath, optimize=True, quality=85)
+                        imageFile.save(cachedImagePath, optimize=True, quality=85)
                     except IOError as e:
                         print(f'Failed to open image at path {cachedImagePath} for resize, caching at original resolution, error: {e}')
                 except Exception as e:


### PR DESCRIPTION
Kept receiving the error 
"AttributeError: 'JpegImageFile' object has no attribute 'attrib'"
and found the image resizing subroutine was overwriting the reference to the xml object. With this it builds on Python 3.13 with the newest version of all dependencies.